### PR TITLE
Support code signing macOS app bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Currently if you need to produce a build you need to run the packer in different
   `npx nodegui-packer --pack <path to dist>`
   
   This command essential takes the dist folder as the input and puts it in the suitable location inside the standalone executable. Also it runs the correct deployment tool (macdeployqt incase of mac, etc) and packs in the dependencies. The output of the command is found under the build directory. You should gitignore the build directory.
+  
+- macOS supports signing the application:
+
+  `npx nodegui-packer --pack <path to dist> --sign <identity>`
+  
+  Identity should be added to the keychain and trusted first. Its value can be copied from: `security find-identity -p codesigning`
 
 # How does it work ?
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,8 @@ import { getPacker } from "./index";
 
 program
   .option("-i, --init <name>", "Creates initial deploy files")
-  .option("-p, --pack <distPath>", "Packs the app into deployable");
+  .option("-p, --pack <distPath>", "Packs the app into deployable")
+  .option("-s, --sign <identity>", "Signs the app during packing using identity (macOS)");
 
 program.parse(process.argv);
 const options = program.opts();
@@ -19,5 +20,5 @@ if (program.init) {
 }
 
 if (program.pack) {
-  packer.pack(options.pack);
+  packer.pack(options.pack, options.sign);
 }


### PR DESCRIPTION
I couldn't run the packed apps on macOS Catalina (10.15.3) unless they were signed, providing the `-codesign` flag to `macdeployqt`. This allows specifying the identity for signing with an optional `-s / --sign <identity>` CLI flag.