### PR TITLE
Add -dmg switch to macdeployqt

### DIFF
--- a/src/darwin/helpers.ts
+++ b/src/darwin/helpers.ts
@@ -64,6 +64,7 @@ export async function runMacDeployQt({
     `${appName}.app`,
     "-verbose=3",
     `-libpath=${qode.qtHome}`,
+    '-dmg',
     ...addonCommands(allAddons),
   ];
 


### PR DESCRIPTION
The `macdeployqt` step was missing the `-dmg` switch, so was not generating the `dmg` file correctly.