### PR TITLE
Fixes getAllNodeAddons matches non '.node' suffix files

### DIFF
--- a/src/darwin/helpers.ts
+++ b/src/darwin/helpers.ts
@@ -17,7 +17,7 @@ function getAllNodeAddons(dirPath: string) {
   const addonExt = "node";
   let dir = fs.readdirSync(dirPath);
   return dir
-    .filter((elm) => elm.match(new RegExp(`.*\.(${addonExt})`, "ig")))
+    .filter((elm) => elm.match(new RegExp(`.*\.(${addonExt}$)`, "ig")))
     .map((eachElement) => path.resolve(dirPath, eachElement));
 }
 

--- a/src/linux/index.ts
+++ b/src/linux/index.ts
@@ -26,7 +26,7 @@ function getAllNodeAddons(dirPath: string) {
   const addonExt = "node";
   let dir = fs.readdirSync(dirPath);
   return dir
-    .filter(elm => elm.match(new RegExp(`.*\.(${addonExt})`, "ig")))
+    .filter(elm => elm.match(new RegExp(`.*\.(${addonExt}$)`, "ig")))
     .map(eachElement => path.resolve(dirPath, eachElement));
 }
 

--- a/src/win32/index.ts
+++ b/src/win32/index.ts
@@ -28,7 +28,7 @@ function getAllNodeAddons(dirPath: string) {
   const addonExt = "node";
   let dir = fs.readdirSync(dirPath);
   return dir
-    .filter(elm => elm.match(new RegExp(`.*\.(${addonExt})`, "ig")))
+    .filter(elm => elm.match(new RegExp(`.*\.(${addonExt}$)`, "ig")))
     .map(eachElement => path.resolve(dirPath, eachElement));
 }
 


### PR DESCRIPTION
The regular expressions in function `getAllNodeAddons` may lead other files containing 'node' to be regarded as node addon, which can leads failure while packing.

On Windows, I've encountered the problem that it passes some JavaScript file generated by webpack whose name contains 'node' to windeployqt, and fails to pack the whole application.

I have fixed this bug in this commit.